### PR TITLE
visualdiffer Now Available via Homebrew Cask

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ For more information, visit the [VisualDiffer Wiki](https://wiki.visualdiffer.co
 > 
 > **Sandboxing** restricts what an app can access on your Mac, for example the application can only access files/folders the user explicitly grants access to.
 
+### From Homebrew
+
+You can install visualdiffer using homebrew with this command:
+
+```bash
+brew install visualdiffer
+```
+
 ### From GitHub Releases
 
 Download from [releases](https://github.com/visualdiffer/visualdiffer/releases/latest), unzip, and drag the app to Applications folder


### PR DESCRIPTION
Hi there,

I’ve submitted PR to homebrew cask and the pull request to add [visualdiffer](https://github.com/Homebrew/homebrew-cask/pull/241608) has been successfully merged, so the cask is now live! You can now install visualdiffer easily through Homebrew using the following command:

```bash
brew install visualdiffer
```


Here is the output when installing visualdiffer
```
❯ brew install visualdiffer
Found existing alias for "brew install". You should use: "bi"
==> Auto-updating Homebrew...
Adjust how often this is run with `$HOMEBREW_AUTO_UPDATE_SECS` or disable with
`$HOMEBREW_NO_AUTO_UPDATE=1`. Hide these hints with `$HOMEBREW_NO_ENV_HINTS=1` (see `man brew`).
==> Auto-updated Homebrew!
==> Updated Homebrew from b344d16251 to 5.0.6 (b64029d4f9).
Updated 3 taps (deskflow/tap, homebrew/core and homebrew/cask).
==> New Formulae
calm-cli: CLI allows you to interact with the Common Architecture Language Model (CALM)
==> New Casks
m32-edit: Remote control for Midas M32 audio consoles
snapmaker-orca: Slicing software for Snapmaker 3D printers, a fork of OrcaSlicer
visualdiffer: Visually compare folders and files

You have 19 outdated formulae and 1 outdated cask installed.


The 5.0.0 release notes are available on the Homebrew Blog:
  https://brew.sh/blog/5.0.0
The 5.0.6 changelog can be found at:
  https://github.com/Homebrew/brew/releases/tag/5.0.6
==> Downloading https://github.com/visualdiffer/visualdiffer/releases/download/v2.1.1/VisualDiffer-2.1.1.zip
Already downloaded: /Users/petruknisme/Library/Caches/Homebrew/downloads/b26a96d114703e6df965206e42fd5a156204d53bd4bffd20418b10bb48237f4a--VisualDiffer-2.1.1.zip
==> Installing Cask visualdiffer
==> Moving App 'VisualDiffer.app' to '/Applications/VisualDiffer.app'
🍺  visualdiffer was successfully installed!
```